### PR TITLE
Improve Dashboard

### DIFF
--- a/views/bookmarkletPage.dhall
+++ b/views/bookmarkletPage.dhall
@@ -1,27 +1,33 @@
 let Prelude =
       https://prelude.dhall-lang.org/v22.0.0/package.dhall
         sha256:1c7622fdc868fe3a23462df3e6f533e50fdc12ecf3b42c0bb45c328ec8c4293e
-let XML = Prelude.XML
 
 let Types = ../types.dhall
 
 let Css = ../utils/css.dhall
+
 let Html = ../utils/html.dhall
 
 let checksets = ../checksets.dhall
+
+let XML = Prelude.XML
 
 let Check/fragments = \(check : Types.Check) -> check.desc.rfcFragments
 
 let CheckSet/fragments =
       \(checkSet : Types.CheckSet) ->
         Prelude.List.foldLeft
-            Types.Check
-            checkSet.checks
-            (List Text)
-            (\(acc : List Text) -> \(cur : Types.Check) -> acc # Check/fragments cur)
-            ([]: List Text)
+          Types.Check
+          checkSet.checks
+          (List Text)
+          ( \(acc : List Text) ->
+            \(cur : Types.Check) ->
+              acc # Check/fragments cur
+          )
+          ([] : List Text)
 
-let fragments = Prelude.List.concatMap Types.CheckSet Text CheckSet/fragments checksets
+let fragments =
+      Prelude.List.concatMap Types.CheckSet Text CheckSet/fragments checksets
 
 let cssSelectors =
       Prelude.List.map
@@ -47,5 +53,6 @@ let linkElem =
 
 let label = XML.rawText "Drag this to your bookmarks bar:"
 
-let page=  Html.outerTemplate "Bookmarklet page" [ label, linkElem ]
+let page = Html.outerTemplate "Bookmarklet page" [ label, linkElem ]
+
 in  "<!DOCTYPE html>" ++ XML.render page


### PR DESCRIPTION
This is what the dashboard looks like after this PR:

![image](https://github.com/user-attachments/assets/887cb212-59b5-4716-a9fb-a6a2b0c08a7f)

- The ids are now of the format "valn01234":
  - 0-padded to 4 digits
  - "valn" (short for validation) to signal what the number means when used in other contexts
- The ¶ on the left is a link to the current check in the dashboard, so we can link to it
- the "search code" links to github search, searching for the id in the openmls repo