### PR TITLE
Annotate and fix missing validation checks, including ones we hadn't catalogued before

### DIFF
--- a/checksets.dhall
+++ b/checksets.dhall
@@ -11,4 +11,5 @@
 , ./checksets/11-update-path.dhall
 , ./checksets/12-commit.dhall
 , ./checksets/13-framing.dhall
+, ./checksets/14-welcome.dhall
 ]

--- a/checksets/01-leaf_node.dhall
+++ b/checksets/01-leaf_node.dhall
@@ -124,7 +124,9 @@ let checks =
             types.Status.Partial
             types.CodeRefs/empty
             types.CodeRefs/empty
-            (types.Notes/single "check is implemented, still needs to be tested.")
+            ( types.Notes/single
+                "check is implemented, still needs to be tested."
+            )
         , types.Check/new
             7
             ( types.RfcRef/single

--- a/checksets/02-key_package.dhall
+++ b/checksets/02-key_package.dhall
@@ -84,6 +84,20 @@ let checks =
           )
           types.CodeRefs/empty
           (types.Notes/single "todo: add test ref")
+      , types.Check/new
+          5
+          ( types.RfcRef/single
+              ''
+              If a client receives a KeyPackage carried within an MLSMessage object, then it MUST
+              verify that the version field of the KeyPackage has the same value as the version
+              field of the MLSMessage.
+              ''
+              "section-10-7"
+          )
+          types.Status.Partial
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          (types.Notes/single "todo: add test ref")
       ]
 
 in  types.CheckSet/new id name desc checks

--- a/checksets/04-external_commit_proposal_list.dhall
+++ b/checksets/04-external_commit_proposal_list.dhall
@@ -75,6 +75,61 @@ let checks =
           ( types.Notes/single
               "The check is implemented, but we need to test that we do it correctly"
           )
+      , types.Check/new
+          5
+          ( types.RfcRef/single
+              ''
+              External Commits MUST contain a path field (and is therefore a "full" Commit). The joiner is added at the leftmost free leaf node
+              (just as if they were added with an Add proposal), and the path is calculated relative to that leaf node.
+              ''
+              "section-12.4.3.2-11.1")
+          types.Status.Partial
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          ( types.Notes/single
+              "The check is implemented, but we need to test that we do it correctly"
+          )
+      , types.Check/new
+          6
+          ( types.RfcRef/single
+              ''
+              The Commit MUST NOT include any proposals by reference, since an external joiner cannot determine the validity of proposals sent
+              within the group.
+              ''
+              "section-12.4.3.2-11.2")
+          types.Status.Partial
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          ( types.Notes/single
+              "The check is implemented, but we need to test that we do it correctly"
+          )
+      , types.Check/new
+          7
+          ( types.RfcRef/single
+              ''
+              External Commits MUST be signed by the new member. In particular, the signature on the enclosing AuthenticatedContent MUST verify
+              using the public key for the credential in the leaf_node of the path field.
+              ''
+              "section-12.4.3.2-11.3")
+          types.Status.Partial
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          ( types.Notes/single
+              "The check is implemented, but we need to test that we do it correctly"
+          )
+      , types.Check/new
+          8
+          ( types.RfcRef/single
+              ''
+              The sender type for the AuthenticatedContent encapsulating the external Commit MUST be new_member_commit.
+              ''
+              "section-12.4.3.2-11.5")
+          types.Status.Partial
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          ( types.Notes/single
+              "This is implicit, because it's the value on which our decision how to process the message is based."
+          )
       ]
 
 in  types.CheckSet/new id name desc checks

--- a/checksets/04-external_commit_proposal_list.dhall
+++ b/checksets/04-external_commit_proposal_list.dhall
@@ -82,7 +82,8 @@ let checks =
               External Commits MUST contain a path field (and is therefore a "full" Commit). The joiner is added at the leftmost free leaf node
               (just as if they were added with an Add proposal), and the path is calculated relative to that leaf node.
               ''
-              "section-12.4.3.2-11.1")
+              "section-12.4.3.2-11.1"
+          )
           types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
@@ -96,7 +97,8 @@ let checks =
               The Commit MUST NOT include any proposals by reference, since an external joiner cannot determine the validity of proposals sent
               within the group.
               ''
-              "section-12.4.3.2-11.2")
+              "section-12.4.3.2-11.2"
+          )
           types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
@@ -110,7 +112,8 @@ let checks =
               External Commits MUST be signed by the new member. In particular, the signature on the enclosing AuthenticatedContent MUST verify
               using the public key for the credential in the leaf_node of the path field.
               ''
-              "section-12.4.3.2-11.3")
+              "section-12.4.3.2-11.3"
+          )
           types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
@@ -123,7 +126,8 @@ let checks =
               ''
               The sender type for the AuthenticatedContent encapsulating the external Commit MUST be new_member_commit.
               ''
-              "section-12.4.3.2-11.5")
+              "section-12.4.3.2-11.5"
+          )
           types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty

--- a/checksets/04-external_commit_proposal_list.dhall
+++ b/checksets/04-external_commit_proposal_list.dhall
@@ -44,12 +44,14 @@ let checks =
               ''
               "section-12.2-6.2"
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
           ( types.Notes/single
               ''
-              reported in https://github.com/xmtp/openmls/pull/19
+              We are checking that there are is not more than one Remove proposal
+              in external commits, but the application has to ensure that the
+              provided key package satisfies the requirements.
               ''
           )
       , types.Check/new

--- a/checksets/14-welcome.dhall
+++ b/checksets/14-welcome.dhall
@@ -55,7 +55,9 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          (types.Notes/single "This is an application-level concern. We only handle individual groups")
+          ( types.Notes/single
+              "This is an application-level concern. We only handle individual groups"
+          )
       , types.Check/new
           4
           ( types.RfcRef/single
@@ -68,15 +70,16 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          (types.Notes/single 
+          ( types.Notes/single
               ''
-              This one is a bit unclear. It does not clearly state which key package is meant
+              This one is a bit unclear. It does not clearly stated which key package is meant
               (though we can guess it's the new member's key package), and also GroupInfo itself
               doesn't even have a cipher_suite.
               And what about the cipher_suite of the Welcome message itself?
               The current status is that we don't do the check, be compare the cipher_suite fields
               of key package and welcome message.
-              '')
+              ''
+          )
       , types.Check/new
           5
           ( types.RfcRef/new
@@ -121,16 +124,20 @@ let checks =
           8
           ( types.RfcRef/new
               ''
-              Verify the integrity of the ratchet tree: 
+              Verify the integrity of the ratchet tree:
               For each non-empty parent node and each entry in the node's unmerged_leaves field:
-              Verify that the entry represents a non-blank leaf node that is a descendant of the parent node.
+              Verify that the entry represents a non-blank leaf node that is a descendant of the
+              parent node.
               ''
-              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.1" ]
+              [ "section-12.4.3.1-12.4.1"
+              , "section-12.4.3.1-12.4.2.4.1"
+              , "section-12.4.3.1-12.4.2.4.2.1"
+              ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           9
           ( types.RfcRef/new
@@ -140,12 +147,15 @@ let checks =
               Verify that every non-blank intermediate node between the leaf node and the parent
               node also has an entry for the leaf node in its unmerged_leaves.
               ''
-              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.2" ]
+              [ "section-12.4.3.1-12.4.1"
+              , "section-12.4.3.1-12.4.2.4.1"
+              , "section-12.4.3.1-12.4.2.4.2.2"
+              ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           10
           ( types.RfcRef/new
@@ -155,7 +165,10 @@ let checks =
               Verify that the encryption key in the parent node does not appear in any other node of
               the tree.
               ''
-              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.3" ]
+              [ "section-12.4.3.1-12.4.1"
+              , "section-12.4.3.1-12.4.2.4.1"
+              , "section-12.4.3.1-12.4.2.4.2.3"
+              ]
           )
           types.Status.Partial
           types.CodeRefs/empty
@@ -224,4 +237,3 @@ let checks =
       ]
 
 in  types.CheckSet/new id name desc checks
-

--- a/checksets/14-welcome.dhall
+++ b/checksets/14-welcome.dhall
@@ -27,7 +27,7 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "reinit and branch are not implement so far")
       , types.Check/new
           2
           ( types.RfcRef/single
@@ -39,10 +39,10 @@ let checks =
               ''
               "section-12.4.3.1-12.1"
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           3
           ( types.RfcRef/single
@@ -55,7 +55,7 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "This is an application-level concern. We only handle individual groups")
       , types.Check/new
           4
           ( types.RfcRef/single
@@ -68,7 +68,15 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single 
+              ''
+              This one is a bit unclear. It does not clearly state which key package is meant
+              (though we can guess it's the new member's key package), and also GroupInfo itself
+              doesn't even have a cipher_suite.
+              And what about the cipher_suite of the Welcome message itself?
+              The current status is that we don't do the check, be compare the cipher_suite fields
+              of key package and welcome message.
+              '')
       , types.Check/new
           5
           ( types.RfcRef/new
@@ -78,10 +86,10 @@ let checks =
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.1" ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           6
           ( types.RfcRef/new
@@ -92,10 +100,10 @@ let checks =
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.2" ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           7
           ( types.RfcRef/new
@@ -105,10 +113,10 @@ let checks =
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.3" ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           8
           ( types.RfcRef/new
@@ -149,16 +157,17 @@ let checks =
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.3" ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           11
           ( types.RfcRef/new
               ''
               Verify the integrity of the ratchet tree: 
-              Verify the confirmation tag in the GroupInfo using the derived confirmation key and the confirmed_transcript_hash from the GroupInfo.
+              Verify the confirmation tag in the GroupInfo using the derived confirmation key and
+              the confirmed_transcript_hash from the GroupInfo.
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.9" ]
           )
@@ -179,7 +188,7 @@ let checks =
           types.Status.Missing
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "reinit isn't currently implemented")
       , types.Check/new
           13
           ( types.RfcRef/new

--- a/checksets/14-welcome.dhall
+++ b/checksets/14-welcome.dhall
@@ -67,18 +67,22 @@ let checks =
               ''
               "section-12.4.3.1-12.3"
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          ( types.Notes/single
-              ''
-              This one is a bit unclear. It does not clearly stated which key package is meant
-              (though we can guess it's the new member's key package), and also GroupInfo itself
-              doesn't even have a cipher_suite.
-              And what about the cipher_suite of the Welcome message itself?
-              The current status is that we don't do the check, be compare the cipher_suite fields
-              of key package and welcome message.
-              ''
+          ( types.Notes/new
+              [ ''
+                This one is a bit unclear. It does not clearly stated which key package is meant
+                (though we can guess it's the new member's key package), and also GroupInfo itself
+                doesn't even have a cipher_suite (but the GroupContext in there does).
+                ''
+              , "And what about the cipher_suite of the Welcome message itself?"
+              , ''
+                The current status is that we do the check and compare the group context cipher
+                suite with that of the key package of the new member. We also check that they
+                match with the welcome message.
+                ''
+              ]
           )
       , types.Check/new
           5
@@ -184,10 +188,10 @@ let checks =
               ''
               [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.9" ]
           )
-          types.Status.Missing
+          types.Status.Partial
           types.CodeRefs/empty
           types.CodeRefs/empty
-          types.Notes/empty
+          (types.Notes/single "The test might be missing")
       , types.Check/new
           12
           ( types.RfcRef/new

--- a/checksets/14-welcome.dhall
+++ b/checksets/14-welcome.dhall
@@ -1,0 +1,218 @@
+let types = ../types.dhall
+
+let id = 14
+
+let name = "Welcome Validation"
+
+let descText =
+      ''
+      <p>
+      On receiving a Welcome message, a client processes it using the following steps:
+      </p>
+      ''
+
+let desc = types.RfcRef/single descText "section-12.4.3.1-7"
+
+let checks =
+      [ types.Check/new
+          1
+          ( types.RfcRef/single
+              ''
+              If a PreSharedKeyID is part of the GroupSecrets and the client is not in possession of
+              the corresponding PSK, return an error. Additionally, if a PreSharedKeyID has type
+              resumption with usage reinit or branch, verify that it is the only such PSK.
+              ''
+              "section-12.4.3.1-10.1"
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          2
+          ( types.RfcRef/single
+              ''
+              Verify the signature on the GroupInfo object. The signature input comprises all of the
+              fields in the GroupInfo object except the signature field. The public key is taken
+              from the LeafNode of the ratchet tree with leaf index signer. If the node is blank or
+              if signature verification fails, return an error.
+              ''
+              "section-12.4.3.1-12.1"
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          3
+          ( types.RfcRef/single
+              ''
+              Verify that the group_id is unique among the groups that the client is currently
+              participating in.
+              ''
+              "section-12.4.3.1-12.2"
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          4
+          ( types.RfcRef/single
+              ''
+              Verify that the cipher_suite in the GroupInfo matches the cipher_suite in the
+              KeyPackage.
+              ''
+              "section-12.4.3.1-12.3"
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          5
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              Verify that the tree hash of the ratchet tree matches the tree_hash field in GroupInfo.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.1" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          6
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For each non-empty parent node, verify that it is "parent-hash valid", as described in
+              Section 7.9.2.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.2" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          7
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For each non-empty leaf node, validate the LeafNode as described in Section 7.3.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.3" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          8
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For each non-empty parent node and each entry in the node's unmerged_leaves field:
+              Verify that the entry represents a non-blank leaf node that is a descendant of the parent node.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.1" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          9
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For each non-empty parent node and each entry in the node's unmerged_leaves field:
+              Verify that every non-blank intermediate node between the leaf node and the parent
+              node also has an entry for the leaf node in its unmerged_leaves.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.2" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          10
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For each non-empty parent node and each entry in the node's unmerged_leaves field:
+              Verify that the encryption key in the parent node does not appear in any other node of
+              the tree.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.4.2.4.1", "section-12.4.3.1-12.4.2.4.2.3" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          11
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              Verify the confirmation tag in the GroupInfo using the derived confirmation key and the confirmed_transcript_hash from the GroupInfo.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.9" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          12
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              If a PreSharedKeyID was used that has type resumption with usage reinit or branch,
+              verify that the epoch field in the GroupInfo is equal to 1.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.11.1" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          types.Notes/empty
+      , types.Check/new
+          13
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For usage reinit, verify that the last Commit to the referenced group contains a
+              ReInit proposal and that the group_id, version, cipher_suite, and
+              group_context.extensions fields of the GroupInfo match the ReInit proposal.
+              Additionally, verify that all the members of the old group are also members of the new
+              group, according to the application.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.11.2.1" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          (types.Notes/single "reinit isn't currently implemented")
+      , types.Check/new
+          14
+          ( types.RfcRef/new
+              ''
+              Verify the integrity of the ratchet tree: 
+              For usage branch, verify that the version and cipher_suite of the new group match
+              those of the old group, and that the members of the new group compose a subset of the
+              members of the old group, according to the application.
+              ''
+              [ "section-12.4.3.1-12.4.1", "section-12.4.3.1-12.11.2.2" ]
+          )
+          types.Status.Missing
+          types.CodeRefs/empty
+          types.CodeRefs/empty
+          (types.Notes/single "branching isn't currently implemented")
+      ]
+
+in  types.CheckSet/new id name desc checks
+

--- a/utils/css.dhall
+++ b/utils/css.dhall
@@ -1,6 +1,7 @@
 let Prelude =
       https://prelude.dhall-lang.org/v22.0.0/package.dhall
         sha256:1c7622fdc868fe3a23462df3e6f533e50fdc12ecf3b42c0bb45c328ec8c4293e
+
 let XML = Prelude.XML
 
 let Property


### PR DESCRIPTION
This adds validation for external commits and welcomes, and protocol versions.

Fixes #800
Fixes #803
Fixes #807
Fixes #1536