### PR TITLE
add valn0113 to dashboard

### DIFF
--- a/checksets/01-leaf_node.dhall
+++ b/checksets/01-leaf_node.dhall
@@ -231,6 +231,18 @@ let checks =
             )
             types.CodeRefs/empty
             (types.Notes/single "todo: add test ref")
+        , types.Check/new
+            13
+            ( types.RfcRef/new
+                ''
+                Verify that the credential type used in the LeafNode is included in the credentials field of the capabilities field.
+                ''
+                [ "section-7.2-7" ]
+            )
+            types.Status.Partial
+            types.CodeRefs/empty
+            types.CodeRefs/empty
+            (types.Notes/single "todo: add test ref")
         ]
       : List types.Check
 


### PR DESCRIPTION
Add a new validation check (checking that the LeafNode's credential is supported in the credentials field of its Capabilities - https://www.rfc-editor.org/rfc/rfc9420.html#section-7.2-7)

Fixes #27 