### PR TITLE
update status and notes for valn1504

### DIFF
--- a/checksets/15-external_proposal.dhall
+++ b/checksets/15-external_proposal.dhall
@@ -59,10 +59,10 @@ let checks =
               ''
               ["section-6.1-4", "section-6.1-5.4"]
           )
-          types.Status.Missing
+          types.Status.Complete
           types.CodeRefs/empty
           types.CodeRefs/empty
-          (types.Notes/single "todo: add test refs")
+          types.Notes/empty
       ]
 
 in  types.CheckSet/new id name desc checks


### PR DESCRIPTION
This PR updates the status and notes for  the validation test valn1504.
The described changes in the OpenMLS repository were merged in https://github.com/openmls/openmls/pull/1782.