### PR TITLE
New checks: added leaf node must support all group context extensions

### DIFF
--- a/checksets/05-add_proposal.dhall
+++ b/checksets/05-add_proposal.dhall
@@ -27,6 +27,21 @@ let checks =
           types.Status.Complete
           types.Status.Unknown
           types.Notes/empty
+      , types.Check/new
+          2
+          ( types.RfcRef/single
+              ''
+              A client adding a new member to a group MUST verify that the LeafNode for
+              the new member is compatible with the group's extensions. The capabilities
+              field MUST indicate support for each extension in the GroupContext.
+              An Add proposal is invalid if the KeyPackage is invalid according to
+              Section 10.1.
+              ''
+              "section-13.4-5.5"
+          )
+          types.Status.Complete
+          types.Status.Unknown
+          types.Notes/empty
       ]
 
 in  types.CheckSet/new id name desc checks

--- a/checksets/14-welcome.dhall
+++ b/checksets/14-welcome.dhall
@@ -224,6 +224,19 @@ let checks =
           types.Status.Missing
           types.Status.Missing
           (types.Notes/single "branching isn't currently implemented")
+      , types.Check/new
+          15
+          ( types.RfcRef/single
+              ''
+              A client joining a group MUST verify that it supports every extension in the
+              GroupContext for the group. Otherwise, it MUST treat the enclosing GroupInfo
+              message as invalid and not join the group.
+              ''
+              "section-13.4-5.6"
+          )
+          types.Status.Complete
+          types.Status.Unknown
+          types.Notes/empty
       ]
 
 in  types.CheckSet/new id name desc checks


### PR DESCRIPTION
Before we merge this here, we must get the validation fixes from https://github.com/openmls/openmls/pull/1933 in, because we claim these checks are "Completed".